### PR TITLE
fix: 数据库表格中复选框列在同行其他列发生换行导致行高增加时，变为居中对齐了，跟默认主题表现不一致

### DIFF
--- a/styles/protyle/database.scss
+++ b/styles/protyle/database.scss
@@ -548,9 +548,9 @@ $chip-border-radius: 5px;
       }
 
       &::before {
-        top: 0;
-        bottom: 0;
-        margin: auto;
+        top: 5px;
+        bottom: auto;
+        margin: 0;
       }
     }
 


### PR DESCRIPTION
数据库表格中**复选框**列在同行其他列发生换行导致行高增加时，变为居中对齐了，跟默认主题表现不一致
修改前：
<img width="600" alt="修改前" src="https://github.com/user-attachments/assets/a8cc10ef-5112-4009-929f-a2d787bf5fcb" />
修改后：
<img width="600" alt="修改后" src="https://github.com/user-attachments/assets/3cb56d52-2c05-49b4-bda8-fc1089dcb551" />
